### PR TITLE
Update for 03/2024 (use debugpy debugger extension, bullseye base image)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster AS dev
+FROM python:3.8-bullseye AS dev
 RUN apt-get -qq update && apt-get install -qq -y git curl bash zip
 
 ENV DOCKER_VERSION=20.10.11

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,12 +23,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "ms-python.python",
-        "ms-python.vscode-pylance",
-        "njpwerner.autodocstring",
-        "ms-azuretools.vscode-docker",
-        "redhat.vscode-yaml",
-        "kddejong.vscode-cfn-lint"
+        "ms-python.python@2024.2.1",
+        "ms-python.vscode-pylance@2024.3.2",
+        "njpwerner.autodocstring@0.6.1",
+        "ms-azuretools.vscode-docker@1.29.0",
+        "redhat.vscode-yaml@1.14.0",
+        "kddejong.vscode-cfn-lint@0.25.4"
       ],
       "settings": {
         "python.pythonPath": "/usr/local/bin/python"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,10 +29,7 @@
         "ms-azuretools.vscode-docker@1.29.0",
         "redhat.vscode-yaml@1.14.0",
         "kddejong.vscode-cfn-lint@0.25.4"
-      ],
-      "settings": {
-        "python.pythonPath": "/usr/local/bin/python"
-      }
+      ]
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,15 +20,19 @@
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=delegated",
   ],
-  "extensions": [
-    "ms-python.python",
-    "ms-python.vscode-pylance",
-    "njpwerner.autodocstring",
-    "ms-azuretools.vscode-docker",
-    "redhat.vscode-yaml",
-    "kddejong.vscode-cfn-lint"
-  ],
-  "settings": {
-    "python.pythonPath": "/usr/local/bin/python"
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "njpwerner.autodocstring",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml",
+        "kddejong.vscode-cfn-lint"
+      ],
+      "settings": {
+        "python.pythonPath": "/usr/local/bin/python"
+      }
+    }
   }
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,11 +3,13 @@
   "configurations": [
     {
       "name": "Python: Remote Attach",
-      "type": "python",
+      "type": "debugpy",
       "request": "attach",
       "preLaunchTask": "Debug Python Lambda Function",
-      "port": 5890,
-      "host": "host.docker.internal",
+      "connect": {
+        "port": 5890,
+        "host": "host.docker.internal",
+      },
       "pathMappings": [
         {
           "localRoot": "${workspaceFolder}/src",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
       "source.organizeImports": "explicit"
     }
   },
+  "python.defaultInterpreterPath": "/usr/local/bin/python",
   "python.languageServer": "Pylance",
   "python.analysis.typeCheckingMode": "basic",
   "python.analysis.autoImportCompletions": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,7 +30,7 @@
     "editor.insertSpaces": true,
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   },
   "python.pythonPath": "/usr/local/bin/python",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "terminal.integrated.shell.linux": "/bin/bash",
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
@@ -33,18 +32,9 @@
       "source.organizeImports": "explicit"
     }
   },
-  "python.pythonPath": "/usr/local/bin/python",
-  "python.formatting.provider": "black",
   "python.languageServer": "Pylance",
   "python.analysis.typeCheckingMode": "basic",
   "python.analysis.autoImportCompletions": false,
-  "python.sortImports.args": [
-    "--profile=black"
-  ],
-  "python.linting.enabled": true,
-  "python.linting.lintOnSave": true,
-  "python.linting.pylintEnabled": true,
-  "python.linting.pylintUseMinimalCheckers": false,
   "python.testing.pytestEnabled": true,
   "python.testing.autoTestDiscoverOnSaveEnabled": true,
   "python.analysis.extraPaths": [

--- a/README.md
+++ b/README.md
@@ -19,5 +19,15 @@ Develop and debug AWS SAM functions locally from VS Code Dev Containers
 
 3. Open the cloned folder in VS Code. You'll be prompted to reopen in container, agree by pressing "Reopen in container".
 3. Wait for container image to build and container to launch and VS Code extensions to download.
-4. Go to [`./src/main.py`](https://github.com/ilyasotkov/aws-sam-local-python-devcontainer/blob/main/src/main.py). Uncomment all commented out lines so that the Lambda function will wait for VS Code debugger to attach. Set a breakpoint in the `lambda_handler` function.
+4. Go to [`./src/main.py`](https://github.com/ilyasotkov/aws-sam-local-python-devcontainer/blob/main/src/main.py). Uncomment all commented out lines (this is so that the Lambda function will wait for VS Code debugger to attach). Set a breakpoint in the `lambda_handler` function at the `print(json.dumps(event, indent=2))` line.
 5. Go to the debug tab in VS Code, and press on "Start Debugging". Debugger should automatically attach and hit the breakpoint that you've set.
+
+## Common issues
+
+### `Configured debug type 'debugpy' is not supported.`
+
+Happens because you `Start Debugging` while the `ms-python.debugpy` VSCode extension is still installing. Solution: wait for the extension to install, you can check the installation status it in VSCode's Extensions view.
+
+### Does not work on arm64
+
+This repo has only been tested on x86_64 architecture. If you get it working on arm64, feel free to submit a PR!

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Develop and debug AWS SAM functions locally from VS Code Dev Containers
 
 ### `Configured debug type 'debugpy' is not supported.`
 
-Happens because you `Start Debugging` while the `ms-python.debugpy` VSCode extension is still installing. Solution: wait for the extension to install, you can check the installation status it in VSCode's Extensions view.
+Happens because you `Start Debugging` while the `ms-python.debugpy` VSCode extension is still installing. Solution: wait for the extension to install, you can check the installation status in VSCode's Extensions view.
 
 ### Does not work on arm64
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,3 @@
-pylint==2.6.0
-black==20.8b1
-rope==0.18.0
 debugpy==1.2.0
 aws-sam-cli==1.36.0
 cfn-lint==0.56.3


### PR DESCRIPTION
- Use `bullseye` base image for devcontainer (still Python 3.8)
- Update VSCode settings for latest VSCode version (tested on 1.88.0-insider)
- Remove linting and formatting functionality (it's no longer shipped with the python extension, and doesn't really have much to do with the purpose of this repository)