### PR TITLE
Simplify instructions for Linux and GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,9 @@
     "target": "dev"
   },
   "runArgs": [
-    // Needed for Linux and GitHub Codespaces, including GitHub Codespaces
+    // Needed for Linux and GitHub Codespaces, feel free to remove if you only need this to work on macOS
     "--add-host=host.docker.internal:host-gateway"
-    // Use this for Docker Engine <20.10.x
+    // For Linux with Docker Engine <20.10.x, use this instead
     // "--add-host=host.docker.internal:172.17.0.1"
   ],
   "shutdownAction": "stopContainer",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,9 @@
     "target": "dev"
   },
   "runArgs": [
-    // Uncomment line below for Linux hosts with Docker >=20.10.x
-    // "--add-host=host.docker.internal:host-gateway"
-    // Uncomment line below for Linux hosts with Docker <20.10.x
+    // Needed for Linux and GitHub Codespaces, including GitHub Codespaces
+    "--add-host=host.docker.internal:host-gateway"
+    // Use this for Docker Engine <20.10.x
     // "--add-host=host.docker.internal:172.17.0.1"
   ],
   "shutdownAction": "stopContainer",

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Develop and debug AWS SAM functions locally from VS Code Dev Containers
 
 ## Prerequisites
 
-- Docker (tested on macOS, Linux, and GitHub Codespaces)
+- Docker (tested on macOS, Linux)
 - VS Code with *Remote - Containers* extension installed
+
+Also works in GitHub Codespaces.
 
 ## Usage
 
@@ -15,9 +17,7 @@ Develop and debug AWS SAM functions locally from VS Code Dev Containers
     ```sh
     git clone https://github.com/ilyasotkov/aws-sam-local-python-devcontainer.git
     ```
-2. (Only needed on Linux or GitHub Codespaces): Modify [.devcontainer/devcontainer.json](https://github.com/ilyasotkov/aws-sam-local-python-devcontainer/blob/main/.devcontainer/devcontainer.json) by uncommenting one of the lines in `runArgs` property depending on your Docker version.
-
-3. Open the cloned folder in VS Code. You'll be prompted to reopen in container, agree by pressing "Reopen in container".
+2. Open the cloned folder in VS Code. You'll be prompted to reopen in container, agree by pressing "Reopen in container".
 3. Wait for container image to build and container to launch and VS Code extensions to download.
 4. Go to [`./src/main.py`](https://github.com/ilyasotkov/aws-sam-local-python-devcontainer/blob/main/src/main.py). Uncomment all commented out lines (this is so that the Lambda function will wait for VS Code debugger to attach). Set a breakpoint in the `lambda_handler` function at the `print(json.dumps(event, indent=2))` line.
 5. Go to the debug tab in VS Code, and press on "Start Debugging". Debugger should automatically attach and hit the breakpoint that you've set.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Develop and debug AWS SAM functions locally from VS Code Dev Containers
 
 ## Prerequisites
 
-- Docker (tested on macOS and Linux)
+- Docker (tested on macOS, Linux, and GitHub Codespaces)
 - VS Code with *Remote - Containers* extension installed
 
 ## Usage
@@ -15,7 +15,7 @@ Develop and debug AWS SAM functions locally from VS Code Dev Containers
     ```sh
     git clone https://github.com/ilyasotkov/aws-sam-local-python-devcontainer.git
     ```
-2. (Only needed on Linux): Modify [.devcontainer/devcontainer.json](https://github.com/ilyasotkov/aws-sam-local-python-devcontainer/blob/main/.devcontainer/devcontainer.json) by uncommenting one of the lines in `runArgs` property depending on your Docker version.
+2. (Only needed on Linux or GitHub Codespaces): Modify [.devcontainer/devcontainer.json](https://github.com/ilyasotkov/aws-sam-local-python-devcontainer/blob/main/.devcontainer/devcontainer.json) by uncommenting one of the lines in `runArgs` property depending on your Docker version.
 
 3. Open the cloned folder in VS Code. You'll be prompted to reopen in container, agree by pressing "Reopen in container".
 3. Wait for container image to build and container to launch and VS Code extensions to download.


### PR DESCRIPTION
`--add-host=host.docker.internal:host-gateway` works with macOS and necessary for Linux and Codespaces, so we can simplify the instructions